### PR TITLE
Improved await() regarding failing/rejected promises

### DIFF
--- a/lib/Mojo/AsyncAwait.pm
+++ b/lib/Mojo/AsyncAwait.pm
@@ -187,7 +187,8 @@ method), it will be wrapped in a Mojo::Promise for consistency. This is mostly
 inconsequential to the user.
 
 Note that await can only take one promise as an argument. If you wanted to
-await multiple promises you probably want L<Mojo::Promise/all>, L<Mojo::Promise/all_settled>, L<Mojo::Promise/any>, or L<Mojo::Promise/race>.
+await multiple promises you probably want L<Mojo::Promise/all>,
+L<Mojo::Promise/all_settled>, L<Mojo::Promise/any>, or L<Mojo::Promise/race>.
 
   my $results = await Mojo::Promise->all(@promises);
 

--- a/lib/Mojo/AsyncAwait.pm
+++ b/lib/Mojo/AsyncAwait.pm
@@ -8,8 +8,11 @@ our $VERSION = '0.03';
 
 my $backend = $ENV{MOJO_ASYNCAWAIT_BACKEND} // '+Coro';
 $backend =~ s/^\+/Mojo::AsyncAwait::Backend::/;
-if(my $e = Mojo::Loader::load_class($backend)) {
-  Carp::croak(ref $e ? $e : "Could not find backend $backend. Perhaps you need to install it?");
+if (my $e = Mojo::Loader::load_class($backend)) {
+  Carp::croak(
+    ref $e
+    ? $e
+    : "Could not find backend $backend. Perhaps you need to install it?");
 }
 
 sub import { $backend->import::into(scalar caller) }
@@ -184,10 +187,21 @@ method), it will be wrapped in a Mojo::Promise for consistency. This is mostly
 inconsequential to the user.
 
 Note that await can only take one promise as an argument. If you wanted to
-await multiple promises you probably want L<Mojo::Promise/all> or less likely
-L<Mojo::Promise/race>.
+await multiple promises you probably want L<Mojo::Promise/all>, L<Mojo::Promise/all_settled>, L<Mojo::Promise/any>, or L<Mojo::Promise/race>.
 
   my $results = await Mojo::Promise->all(@promises);
+
+In case you need to catch the error value for a rejected promise, you need to wrap
+C<await> in an eval function.
+
+  my $tx = eval { await Mojo::UserAgent->new->get_p('https://mojolicious.org') };
+  my $error = $@;
+  chomp($error) if $error;
+
+Alternatively, you may supply a reference to a scalar variable as second argument.
+
+  my $error;
+  my $tx = await Mojo::UserAgent->new->get_p('https://mojolicious.org'), \$error;
 
 =head1 AUTHORS
 
@@ -199,6 +213,8 @@ Marcus Ramberg <mramberg@cpan.org>
 
 Sebastian Riedel <kraih@mojolicious.org>
 
+Markus Jansen <mja@jansen-preisler.de>
+
 =head1 ADDITIONAL THANKS
 
 Matt S Trout (mst)
@@ -209,7 +225,7 @@ John Susek
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 2018, L</AUTHORS> and L</CONTRIBUTORS>.
+Copyright (C) 2018-2021, L</AUTHORS> and L</CONTRIBUTORS>.
 
 This program is free software, you can redistribute it and/or modify it under
 the terms of the Artistic License version 2.0.

--- a/t/await_reject.t
+++ b/t/await_reject.t
@@ -1,0 +1,48 @@
+use Mojo::Base -strict;
+
+use Test::More;
+
+use Mojo::AsyncAwait;
+use Mojo::IOLoop;
+use Mojo::Promise;
+
+sub answer {
+  my $p = Mojo::Promise->new;
+  Mojo::IOLoop->next_tick(sub { $p->reject(42) });
+  return $p;
+}
+
+subtest 'failure (traditional, with eval)' => sub {
+  my ($answer, $eval_err, $async_func_err);
+  async(sub {
+    eval { $answer = await answer() };
+    $eval_err = $@;
+    if ($eval_err) {
+      chomp $eval_err;
+      die "$eval_err\n";
+    }
+  })->()->catch(sub { $async_func_err = shift; chomp $async_func_err; })
+    ->wait;
+
+  ok !defined $answer, 'no answer due to failure';
+  is $eval_err, '42', 'got expected inner error "42"';
+
+# variant for for Mojo::AsyncAwait 0.03 using Carp::croak() instead of die()
+# like $eval_err, qr'42', "got somehow expected answer \"$eval_err\" (just \"42\" would be perfect)";
+  is $async_func_err, '42', 'got expected outer error "42"';
+};
+
+subtest 'failure (traditional, improved - without eval)' => sub {
+  my ($answer, $ref_err, $async_func_err);
+  async(sub {
+    $answer = await answer(), \$ref_err;
+    die "$ref_err\n" if $ref_err;
+  })->()->catch(sub { $async_func_err = shift; chomp $async_func_err })->wait;
+
+  ok !defined $answer, 'no answer due to failure';
+  is $ref_err,        '42', 'got expected inner error "42"';
+  is $async_func_err, '42', 'got expected outer error "42"';
+};
+
+done_testing;
+


### PR DESCRIPTION
…with the possibility to avoid yet another eval wrapper.

I found that await handles the "sunshine" case great, but requires an eval wrapper to catch errors (which further should be passed without source code context information).
IMHO I found a simple way to pass the error information, too.